### PR TITLE
Fix detection in case misconfigured folders don't 403 on checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The extension implements an active scanner check. Simply run a new scan, prefera
 
 *https://i.blackhat.com/us-18/Wed-August-8/us-18-Orange-Tsai-Breaking-Parser-Logic-Take-Your-Path-Normalization-Off-And-Pop-0days-Out-2.pdf*
 
-A server is assumed to be vulnerable if a request to an existing path like `https://example.com/static../` returns 403. To eliminate false positives the misconfiguration has to be confirmed by successfully requesting an existing resource via path traversal. This is done as follows:
+A server is assumed to be vulnerable if a request to an existing path like `https://example.com/static../` returns the same response as `https://example.com/`. To eliminate false positives the misconfiguration has to be confirmed by successfully requesting an existing resource via path traversal. This is done as follows:
 
 For the URL https://example.com/folder1/folder2/static/main.css it generates the following links:
 

--- a/off-by-slash.py
+++ b/off-by-slash.py
@@ -37,7 +37,7 @@ class BurpExtender(IBurpExtender, IScannerCheck):
         self._stdout.println("GitHub: https://github.com/bayotop/off-by-slash/")
         self._stdout.println("Contact: https://twitter.com/_bayotop")
         self._stdout.println("")
-        self._stdout.println("Successfully initialized!")
+        self._stdout.println("Successfully initialized (v1.1)!")
 
     def doActiveScan(self, baseRequestResponse, insertionPoint):
         scan_issues = []


### PR DESCRIPTION
Changes the quick check to compare responses from http://host/some/path../ and http://host/some/ instead of only expecting a 403 status code.

There are also minor naming changes in scrape.py and the code was formatted with [black](https://github.com/psf/black).